### PR TITLE
Make method signature compatible with Laravel Nova v4.

### DIFF
--- a/src/Qrcode.php
+++ b/src/Qrcode.php
@@ -69,7 +69,7 @@ class Qrcode extends Field
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
             'value' => (string) $this->value,


### PR DESCRIPTION
In Laravel Nova v4, the filed is failing with the following. 

[2022-04-29 19:58:22] local.ERROR: Declaration of Kristories\Qrcode\Qrcode::jsonSerialize() must be compatible with Laravel\Nova\Fields\Field::jsonSerialize(): array {"userId":"961ddb06-670d-4d3f-956b-595144f7e4ab","exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Declaration of Kristories\\Qrcode\\Qrcode::jsonSerialize() must be compatible with Laravel\\Nova\\Fields\\Field::jsonSerialize(): array at /var/www/html/vendor/kristories/nova-qrcode-field/src/Qrcode.php:72)
[stacktrace]
#0 {main}
"} 
